### PR TITLE
[improve][broker] Optimize Consumer.individualAck to avoid multiple call pendingAck to find acked consumer.

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
@@ -28,6 +28,7 @@ import io.netty.util.concurrent.Promise;
 import java.util.ArrayList;
 import java.util.BitSet;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -485,14 +486,29 @@ public class Consumer {
 
     //this method is for individual ack not carry the transaction
     private CompletableFuture<Long> individualAckNormal(CommandAck ack, Map<String, Long> properties) {
-        List<Position> positionsAcked = new ArrayList<>();
+        List<Position> positionsAcked = new ArrayList<>(ack.getMessageIdsCount());
+        // use for record position and ack consumers
+        HashMap<PositionImpl, Consumer> ackConsumerMapping = new HashMap<>();
+
         long totalAckCount = 0;
         for (int i = 0; i < ack.getMessageIdsCount(); i++) {
             MessageIdData msgId = ack.getMessageIdAt(i);
             PositionImpl position;
+
+            long ledgerId = msgId.getLedgerId();
+            long entryId = msgId.getEntryId();
+            Consumer ackOwnerConsumer = this;
+
+            long batchSize = 1;
+            if (Subscription.isIndividualAckMode(subType)) {
+                ConsumerAndLongPair consumerAndLongPair = getAckOwnerConsumerAndLongPair(ledgerId, entryId);
+                if (consumerAndLongPair.hasResult()) {
+                    ackOwnerConsumer = consumerAndLongPair.consumer;
+                    batchSize = consumerAndLongPair.pendingAckLongPair.first;
+                }
+            }
+
             long ackedCount = 0;
-            long batchSize = getBatchSize(msgId);
-            Consumer ackOwnerConsumer = getAckOwnerConsumer(msgId.getLedgerId(), msgId.getEntryId());
             if (msgId.getAckSetsCount() > 0) {
                 long[] ackSets = new long[msgId.getAckSetsCount()];
                 for (int j = 0; j < msgId.getAckSetsCount(); j++) {
@@ -511,12 +527,15 @@ public class Consumer {
             } else {
                 position = PositionImpl.get(msgId.getLedgerId(), msgId.getEntryId());
                 ackedCount = getAckedCountForMsgIdNoAckSets(batchSize, position, ackOwnerConsumer);
-                if (checkCanRemovePendingAcksAndHandle(position, msgId)) {
+                if (checkCanRemovePendingAcksAndHandleWithOwnedConsumer(position, msgId, ackOwnerConsumer)) {
                     addAndGetUnAckedMsgs(ackOwnerConsumer, -(int) ackedCount);
                 }
             }
 
             positionsAcked.add(position);
+            if (position.hasAckSet()) {
+                ackConsumerMapping.put(position, ackOwnerConsumer);
+            }
 
             checkAckValidationError(ack, position);
 
@@ -532,7 +551,8 @@ public class Consumer {
                 if (((PositionImpl) position).getAckSet() != null) {
                     if (((PersistentSubscription) subscription)
                             .checkIsCanDeleteConsumerPendingAck((PositionImpl) position)) {
-                        removePendingAcks((PositionImpl) position);
+                        removePendingAckWithOwnedConsumer((PositionImpl) position,
+                                ackConsumerMapping.get(position));
                     }
                 }
             }));
@@ -602,24 +622,6 @@ public class Consumer {
         return completableFuture.thenApply(__ -> totalAckCount.sum());
     }
 
-    private long getBatchSize(MessageIdData msgId) {
-        long batchSize = 1;
-        if (Subscription.isIndividualAckMode(subType)) {
-            LongPair longPair = pendingAcks.get(msgId.getLedgerId(), msgId.getEntryId());
-            // Consumer may ack the msg that not belongs to it.
-            if (longPair == null) {
-                Consumer ackOwnerConsumer = getAckOwnerConsumer(msgId.getLedgerId(), msgId.getEntryId());
-                longPair = ackOwnerConsumer.getPendingAcks().get(msgId.getLedgerId(), msgId.getEntryId());
-                if (longPair != null) {
-                    batchSize = longPair.first;
-                }
-            } else {
-                batchSize = longPair.first;
-            }
-        }
-        return batchSize;
-    }
-
     private long getAckedCountForMsgIdNoAckSets(long batchSize, PositionImpl position, Consumer consumer) {
         if (isAcknowledgmentAtBatchIndexLevelEnabled && Subscription.isIndividualAckMode(subType)) {
             long[] cursorAckSet = getCursorAckSet(position);
@@ -686,16 +688,22 @@ public class Consumer {
         return false;
     }
 
+    private boolean checkCanRemovePendingAcksAndHandleWithOwnedConsumer(PositionImpl position,
+                                                                   MessageIdData msgId,
+                                                                   Consumer ackOwnerConsumer) {
+        if (Subscription.isIndividualAckMode(subType) && msgId.getAckSetsCount() == 0) {
+            return removePendingAckWithOwnedConsumer(position, ackOwnerConsumer);
+        }
+        return false;
+    }
+
+
     private Consumer getAckOwnerConsumer(long ledgerId, long entryId) {
         Consumer ackOwnerConsumer = this;
         if (Subscription.isIndividualAckMode(subType)) {
-            if (!getPendingAcks().containsKey(ledgerId, entryId)) {
-                for (Consumer consumer : subscription.getConsumers()) {
-                    if (consumer != this && consumer.getPendingAcks().containsKey(ledgerId, entryId)) {
-                        ackOwnerConsumer = consumer;
-                        break;
-                    }
-                }
+            ConsumerAndLongPair ackOwnerConsumerAndLongPair = getAckOwnerConsumerAndLongPair(ledgerId, entryId);
+            if (ackOwnerConsumerAndLongPair.hasResult()) {
+                ackOwnerConsumer = ackOwnerConsumerAndLongPair.consumer;
             }
         }
         return ackOwnerConsumer;
@@ -965,43 +973,63 @@ public class Consumer {
      * @param position
      */
     private boolean removePendingAcks(PositionImpl position) {
+        ConsumerAndLongPair ackOwnerConsumerAndLongPair = getAckOwnerConsumerAndLongPair(position.getLedgerId(),
+                position.getEntryId());
+        // remove pending message from appropriate consumer and unblock unAckMsg-flow if requires
+        if (ackOwnerConsumerAndLongPair.pendingAckLongPair != null) {
+            return removePendingAckWithOwnedConsumer(position, ackOwnerConsumerAndLongPair.consumer);
+        }
+
+        return false;
+    }
+
+    record ConsumerAndLongPair(Consumer consumer, LongPair pendingAckLongPair) {
+        public boolean hasResult() {
+            return consumer != null && pendingAckLongPair != null;
+        }
+    }
+
+    private ConsumerAndLongPair getAckOwnerConsumerAndLongPair(long ledgerId, long entryId) {
         Consumer ackOwnedConsumer = null;
-        if (pendingAcks.get(position.getLedgerId(), position.getEntryId()) == null) {
+        LongPair ackedPosition = null;
+
+        LongPair consumerAckPos = pendingAcks.get(ledgerId, entryId);
+        if (consumerAckPos == null) {
             for (Consumer consumer : subscription.getConsumers()) {
-                if (!consumer.equals(this) && consumer.getPendingAcks().containsKey(position.getLedgerId(),
-                        position.getEntryId())) {
+                LongPair pos = consumer.getPendingAcks().get(ledgerId, entryId);
+                if (!consumer.equals(this) && pos != null) {
                     ackOwnedConsumer = consumer;
+                    ackedPosition = pos;
                     break;
                 }
             }
         } else {
             ackOwnedConsumer = this;
+            ackedPosition = consumerAckPos;
         }
 
-        // remove pending message from appropriate consumer and unblock unAckMsg-flow if requires
-        LongPair ackedPosition = ackOwnedConsumer != null
-                ? ackOwnedConsumer.getPendingAcks().get(position.getLedgerId(), position.getEntryId())
-                : null;
-        if (ackedPosition != null) {
-            if (!ackOwnedConsumer.getPendingAcks().remove(position.getLedgerId(), position.getEntryId())) {
-                // Message was already removed by the other consumer
-                return false;
-            }
-            if (log.isDebugEnabled()) {
-                log.debug("[{}-{}] consumer {} received ack {}", topicName, subscription, consumerId, position);
-            }
-            // unblock consumer-throttling when limit check is disabled or receives half of maxUnackedMessages =>
-            // consumer can start again consuming messages
-            int unAckedMsgs = UNACKED_MESSAGES_UPDATER.get(ackOwnedConsumer);
-            if ((((unAckedMsgs <= getMaxUnackedMessages() / 2) && ackOwnedConsumer.blockedConsumerOnUnackedMsgs)
-                    && ackOwnedConsumer.shouldBlockConsumerOnUnackMsgs())
-                    || !shouldBlockConsumerOnUnackMsgs()) {
-                ackOwnedConsumer.blockedConsumerOnUnackedMsgs = false;
-                flowConsumerBlockedPermits(ackOwnedConsumer);
-            }
-            return true;
+        return new ConsumerAndLongPair(ackOwnedConsumer, ackedPosition);
+    }
+
+    private boolean removePendingAckWithOwnedConsumer(PositionImpl position, Consumer ackOwnedConsumer) {
+        if (!ackOwnedConsumer.getPendingAcks().remove(position.getLedgerId(), position.getEntryId())) {
+            // Message was already removed by the other consumer
+            return false;
         }
-        return false;
+        if (log.isDebugEnabled()) {
+            log.debug("[{}-{}] consumer {} received ack {}", topicName, subscription, consumerId, position);
+        }
+        // unblock consumer-throttling when limit check is disabled or receives half of maxUnackedMessages =>
+        // consumer can start again consuming messages
+        int unAckedMsgs = UNACKED_MESSAGES_UPDATER.get(ackOwnedConsumer);
+        if ((((unAckedMsgs <= getMaxUnackedMessages() / 2) && ackOwnedConsumer.blockedConsumerOnUnackedMsgs)
+                && ackOwnedConsumer.shouldBlockConsumerOnUnackMsgs())
+                || !shouldBlockConsumerOnUnackMsgs()) {
+            ackOwnedConsumer.blockedConsumerOnUnackedMsgs = false;
+            flowConsumerBlockedPermits(ackOwnedConsumer);
+        }
+
+        return true;
     }
 
     public ConcurrentLongLongPairHashMap getPendingAcks() {


### PR DESCRIPTION
### Motivation
Current broker logic of individualAck will try to locate position and which consumer is the acked message owner.

but the logic is not shared the information which will call this find logic multiple times.

eg. foreach ack messge:

1. getBatchSize will call find logic.
2. ack logic call find logic.
3. checkCanRemovePendingAcksAndHandle will call find logic.
4. removePendingAck will call find logic.

if the message is own by other consumers, and if consumer within one subscription is huge the performance is very low.

### Modifications
just call one time find logic. and return the origin LongPair to extract information.
when the following logic try to use the pos and owner information. just pass the find owner consumer.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
